### PR TITLE
Consider guest count in slot availability

### DIFF
--- a/app/api/reservations/slots/route.ts
+++ b/app/api/reservations/slots/route.ts
@@ -25,6 +25,8 @@ export async function GET(req: NextRequest) {
   const { searchParams } = new URL(req.url);
   const date = searchParams.get('date');
   const section = searchParams.get('section') ?? 'indoor';
+  const gParam = searchParams.get('guests') ?? '1';
+  const guests = parseInt(gParam.replace('+', ''), 10) || 1;
 
   if (!date) {
     return NextResponse.json({ error: 'Missing date' }, { status: 400 });
@@ -40,14 +42,13 @@ export async function GET(req: NextRequest) {
       continue;
     }
     const slotId = 's_' + start.format('YYYYMMDDHH');
-    let free = false;
+    let capacity = 0;
     for (const doc of tablesSnap.docs) {
       if (!doc.get(`booked.${slotId}`)) {
-        free = true;
-        break;
+        capacity += doc.data().capacity || 0;
       }
     }
-    availability[t] = free;
+    availability[t] = capacity >= guests;
   }
 
   return NextResponse.json({ available: availability });

--- a/components/reservation.tsx
+++ b/components/reservation.tsx
@@ -75,14 +75,19 @@ const handleInputChange = (field: string, value: string) => {
   setFormData((prev) => ({
     ...prev,
     [field]: value,
-    ...(field === 'date' || field === 'section' ? { time: '' } : {}),
+    ...(field === 'date' || field === 'section' || field === 'guests' ? { time: '' } : {}),
   }))
 }
 
   useEffect(() => {
-    if (!formData.date) return
+    if (!formData.date || !formData.guests) return
     setLoadingTimes(true)
-    fetch(`/api/reservations/slots?date=${formData.date}&section=${formData.section}`)
+    const params = new URLSearchParams({
+      date: formData.date,
+      section: formData.section,
+      guests: formData.guests,
+    })
+    fetch(`/api/reservations/slots?${params.toString()}`)
       .then((r) => r.json())
       .then((data) => {
         const avail: Record<string, boolean> = data.available || {}
@@ -92,7 +97,7 @@ const handleInputChange = (field: string, value: string) => {
         setTimes(TIME_OPTIONS.map((t) => ({ value: t, available: false })))
       })
       .finally(() => setLoadingTimes(false))
-  }, [formData.date, formData.section])
+  }, [formData.date, formData.section, formData.guests])
 
   return (
     <section id="reservation" className="py-20 bg-gradient-to-br from-blue-50 to-teal-50">


### PR DESCRIPTION
## Summary
- disable times that lack table capacity for a party
- send guest count to slot availability API

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e4d0d28c88320a592440a2026f018