### PR TITLE
Consider guest count in slot availability

### DIFF
--- a/app/api/reservations/slots/route.ts
+++ b/app/api/reservations/slots/route.ts
@@ -1,54 +1,17 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { adminDb } from '@/lib/firebaseAdmin';
-import dayjs from 'dayjs';
-import utc from 'dayjs/plugin/utc';
-import cpf from 'dayjs/plugin/customParseFormat';
-
-dayjs.extend(utc);
-dayjs.extend(cpf);
-
-function parse(date: string, time: string) {
-  const f = [
-    'YYYY-MM-DD HH:mm', 'YYYY-MM-DD HH:mm:ss',
-    'YYYY-MM-DD hh:mm A', 'YYYY-MM-DD hh:mm:ss A',
-    'YYYY-MM-DD h:mm A',  'YYYY-MM-DD h:mm:ss A',
-  ];
-  return dayjs.utc(`${date} ${time}`.trim(), f, true);
-}
-
-const TIMES = [
-  '5:00 PM','5:30 PM','6:00 PM','6:30 PM','7:00 PM',
-  '7:30 PM','8:00 PM','8:30 PM','9:00 PM'
-];
+import { slotAvailability } from '@/lib/reservationUtils';
 
 export async function GET(req: NextRequest) {
   const { searchParams } = new URL(req.url);
   const date = searchParams.get('date');
   const section = searchParams.get('section') ?? 'indoor';
+  const gParam = searchParams.get('guests') ?? '1';
+  const guests = parseInt(gParam.replace('+', ''), 10) || 1;
 
   if (!date) {
     return NextResponse.json({ error: 'Missing date' }, { status: 400 });
   }
 
-  const tablesSnap = await adminDb.collection(`sections/${section}/tables`).get();
-  const availability: Record<string, boolean> = {};
-
-  for (const t of TIMES) {
-    const start = parse(date, t);
-    if (!start.isValid()) {
-      availability[t] = false;
-      continue;
-    }
-    const slotId = 's_' + start.format('YYYYMMDDHH');
-    let free = false;
-    for (const doc of tablesSnap.docs) {
-      if (!doc.get(`booked.${slotId}`)) {
-        free = true;
-        break;
-      }
-    }
-    availability[t] = free;
-  }
-
-  return NextResponse.json({ available: availability });
+  const availability = await slotAvailability(section, date, guests);
+  return NextResponse.json({ available });
 }

--- a/components/reservation.tsx
+++ b/components/reservation.tsx
@@ -75,14 +75,19 @@ const handleInputChange = (field: string, value: string) => {
   setFormData((prev) => ({
     ...prev,
     [field]: value,
-    ...(field === 'date' || field === 'section' ? { time: '' } : {}),
+    ...(field === 'date' || field === 'section' || field === 'guests' ? { time: '' } : {}),
   }))
 }
 
   useEffect(() => {
-    if (!formData.date) return
+    if (!formData.date || !formData.guests) return
     setLoadingTimes(true)
-    fetch(`/api/reservations/slots?date=${formData.date}&section=${formData.section}`)
+    const params = new URLSearchParams({
+      date: formData.date,
+      section: formData.section,
+      guests: formData.guests,
+    })
+    fetch(`/api/reservations/slots?${params.toString()}`)
       .then((r) => r.json())
       .then((data) => {
         const avail: Record<string, boolean> = data.available || {}
@@ -92,7 +97,7 @@ const handleInputChange = (field: string, value: string) => {
         setTimes(TIME_OPTIONS.map((t) => ({ value: t, available: false })))
       })
       .finally(() => setLoadingTimes(false))
-  }, [formData.date, formData.section])
+  }, [formData.date, formData.section, formData.guests])
 
   return (
     <section id="reservation" className="py-20 bg-gradient-to-br from-blue-50 to-teal-50">

--- a/lib/reservationUtils.ts
+++ b/lib/reservationUtils.ts
@@ -1,0 +1,68 @@
+import dayjs from 'dayjs'
+import utc from 'dayjs/plugin/utc'
+import cpf from 'dayjs/plugin/customParseFormat'
+import { adminDb } from './firebaseAdmin'
+
+export interface TableInfo { id: string; capacity: number }
+
+dayjs.extend(utc)
+dayjs.extend(cpf)
+
+export function parse(date: string, time: string) {
+  const f = [
+    'YYYY-MM-DD HH:mm', 'YYYY-MM-DD HH:mm:ss',
+    'YYYY-MM-DD hh:mm A', 'YYYY-MM-DD hh:mm:ss A',
+    'YYYY-MM-DD h:mm A',  'YYYY-MM-DD h:mm:ss A',
+  ]
+  return dayjs.utc(`${date} ${time}`.trim(), f, true)
+}
+
+export const TIMES = [
+  '5:00 PM','5:30 PM','6:00 PM','6:30 PM','7:00 PM',
+  '7:30 PM','8:00 PM','8:30 PM','9:00 PM'
+]
+
+export async function availableTables(section: string, slotId: string): Promise<TableInfo[]> {
+  const snap = await adminDb.collection(`sections/${section}/tables`).get()
+  const tables: TableInfo[] = []
+  for (const doc of snap.docs) {
+    if (!doc.get(`booked.${slotId}`)) {
+      tables.push({ id: doc.id, capacity: doc.data().capacity || 0 })
+    }
+  }
+  return tables
+}
+
+export function pickTables(tables: TableInfo[], guests: number): string[] | null {
+  let best: { ids: string[]; cap: number } | null = null
+  const n = tables.length
+  function dfs(i: number, cap: number, ids: string[]) {
+    if (cap >= guests) {
+      if (!best || cap < best.cap) best = { ids: [...ids], cap }
+      return
+    }
+    if (i >= n) return
+    dfs(i + 1, cap + tables[i].capacity, [...ids, tables[i].id])
+    dfs(i + 1, cap, ids)
+  }
+  dfs(0, 0, [])
+  return best ? best.ids : null
+}
+
+export async function findTablesForSlot(section: string, slotId: string, guests: number): Promise<string[] | null> {
+  const tables = await availableTables(section, slotId)
+  return pickTables(tables, guests)
+}
+
+export async function slotAvailability(section: string, date: string, guests: number): Promise<Record<string, boolean>> {
+  const availability: Record<string, boolean> = {}
+  for (const t of TIMES) {
+    const start = parse(date, t)
+    if (!start.isValid()) { availability[t] = false; continue }
+    const slotId = 's_' + start.format('YYYYMMDDHH')
+    const tables = await availableTables(section, slotId)
+    const ids = pickTables(tables, guests)
+    availability[t] = !!ids
+  }
+  return availability
+}


### PR DESCRIPTION
## Summary
- check table combinations when booking
- centralize reservation availability logic
- use new capacity logic in availability API

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e4d0d28c88320a592440a2026f018